### PR TITLE
Eltávolításra került egy importálási hibát okozó felesleges fájlrészlet

### DIFF
--- a/master/Jöjj, Szentlélek, szállj le rám (Rettegi Zsolt).xml
+++ b/master/Jöjj, Szentlélek, szállj le rám (Rettegi Zsolt).xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<song createdIn="OpenLP 2.0.1" modifiedDate="2019-03-26T09:37:26" modifiedIn="openlyrics.py 0.2" version="0.8" xmlns="http://openlyrics.info/namespace/2009/song">
+<song createdIn="OpenLP 2.0.1" modifiedDate="2019-12-10T21:34:57+01:00" modifiedIn="manually" version="0.8" xmlns="http://openlyrics.info/namespace/2009/song">
   <properties>
     <titles>
       <title lang="hu">Jöjj, Szentlélek, szállj le rám</title>
@@ -8,8 +8,6 @@
       <author type="words">Rettegi Zsolt</author>
       <author type="music">Rettegi Zsolt</author>
     </authors>
-    <songbooks>
-    </songbooks>
     <verseOrder>v1</verseOrder>
     <variant>Csiszér László szövegvariánsa</variant>
   </properties>


### PR DESCRIPTION
Szia Gellért!

Az alább javított hiba miatt importálási hiba történt ha valaki a `master` könyvtárban lévő összes éneket megpróbálta beimportálni OpenLP-be.

Attila